### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, except: [:index, :new, :create]
-  before_action :redirect_user, except: [:index, :show]
+  before_action :redirect_user, only: [:edit, :update, :destroy]
 
   def index
     @item = Item.all.order('created_at DESC')
@@ -31,6 +31,14 @@ class ItemsController < ApplicationController
       redirect_to item_path
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to action: :index
+    else
+      render :show
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,7 @@ class ItemsController < ApplicationController
   before_action :redirect_user, only: [:edit, :update, :destroy]
 
   def index
-    @item = Item.all.order('created_at DESC')
+    @item = Item.order('created_at DESC')
   end
 
   def new

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id == @item.user.id %>
       <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
       <% else %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items#, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items#, only: [:index, :new, :create, :show, :edit, :update, :destroy]
+  resources :items
 end


### PR DESCRIPTION
# What

商品削除機能の実装

# Why

ユーザーが不必要な商品を削除できるようにするため

以下、Gyazoのリンク

　ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
　https://gyazo.com/094e391705ed52c5f7ccc8d59e090bc7

追記 5/18 21:10
　config/routes.rb 内のコメントアウトを削除